### PR TITLE
Fix crash in NavBarHairlineFadeBehavior

### DIFF
--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -24,6 +24,9 @@ public final class NavBarHairlineFadeBehavior: ViewControllerLifecycleBehavior {
         navBarHairlineFadeUpdater.enabled = false
     }
 
+    deinit {
+        navBarHairlineFadeUpdater.enabled = false
+    }
 }
 
 public extension NavBarHairlineFadeBehavior {


### PR DESCRIPTION
I have no idea why this is needed, but I was kept getting this after `deinit` was called on the Updater

![screen shot 2018-04-23 at 10 17 43 am](https://user-images.githubusercontent.com/114322/39143269-6a0d7cb2-46fb-11e8-9e13-f9f58f422260.png)

My guess is that the `removeObserver` failed when called in it's own `deinit`. But that feels like it would be a massive bug. Any thoughts @heyltsjay / @jvisenti ?