### PR TITLE
Roll back to CocoaPods 1.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'cocoapods', '1.7.0.beta.3'
+gem 'cocoapods', '~> 1.6.1'
 gem 'xcpretty'
 gem 'fastlane'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,11 +12,11 @@ GEM
     atomos (0.1.3)
     babosa (1.0.2)
     claide (1.0.2)
-    cocoapods (1.7.0.beta.3)
+    cocoapods (1.6.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.7.0.beta.3)
-      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-core (= 1.6.1)
+      cocoapods-deintegrate (>= 1.0.2, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
@@ -30,8 +30,8 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.8.2, < 2.0)
-    cocoapods-core (1.7.0.beta.3)
+      xcodeproj (>= 1.8.1, < 2.0)
+    cocoapods-core (1.6.1)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -67,7 +67,7 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
-    fastlane (2.119.0)
+    fastlane (2.120.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -205,9 +205,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.7.0.beta.3)
+  cocoapods (~> 1.6.1)
   fastlane
   xcpretty
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Swiftilities.podspec
+++ b/Swiftilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Swiftilities"
-  s.version          = "0.21.0"
+  s.version          = "0.21.1"
   s.summary          = "A collection of useful Swift utilities."
   s.swift_version    = '4.2'
 


### PR DESCRIPTION
I believe this fixes #157 

Will just need to publish a new tag `0.21.1` after this is merged.