### PR TITLE
Allow warnings while publishing pod to fix CocoaPods trunk server issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ jobs:
           command: |
             curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run: bundle install
-      - run: bundle exec pod trunk push
+      # Warnings must be ignored on CocoaPods 1.6.1 https://github.com/CocoaPods/CocoaPods/issues/8635
+      - run: bundle exec pod trunk push --allow-warnings
 
 workflows:
   version: 2


### PR DESCRIPTION
Looks like their trunk server is broken. The pod validates locally but their trunk server returns an error when publishing the pod. https://github.com/CocoaPods/CocoaPods/issues/8635

Adding `--allow-warnings` to the trunk publish is the official workaround

```
[!] The Pod Specification did not pass validation.
The following validation failed:
- Warnings: Unrecognized `swift_version` key.
Exited with code 1
```