### PR TITLE
docs: fix URLs in Lifecycle READMEs

### DIFF
--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/readme.md
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/readme.md
@@ -2,7 +2,7 @@
 
 This behavior adds a hairline to the bottom of a `UINavigationBar` and animates its `alpha` alongside a `UIScrollView`'s `contentOffset`
 
-![](https://github.com/Raizlabs/Swiftilities/blob/feature/heyltsjay/behaviors/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/example.gif)
+![](example.gif)
 
 ## Usage
 ```swift

--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Title-Transition/readme.md
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Title-Transition/readme.md
@@ -2,7 +2,7 @@
 
 This behavior manages the interactivity between a title, anywhere in a `UIScrollView` and the title of a `UINavigationBar`. The behavior is defined so as the title subview scrolls under the title, the Nav Bar's title will translate into place. 
 
-![](https://raw.githubusercontent.com/Raizlabs/Swiftilities/feature/heyltsjay/behaviors/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Title-Transition/example.gif)
+![](example.gif)
 
 This behavior is accomplished by leveraging the `UINavigationBar().titleVerticalPositionAdjustment`, allowing the title to play nicely with other `UINavigationItem`s, (since it is using the normal `navigationItem.title`.)
 

--- a/Pod/Classes/Lifecycle/readme.md
+++ b/Pod/Classes/Lifecycle/readme.md
@@ -4,8 +4,8 @@ This is a collection of handy [View Controller Lifecycle Behaviors](http://irace
 
 ## Included Behaviors
 
-- [Nav Bar Hairline Fade](https://github.com/Raizlabs/Swiftilities/tree/feature/heyltsjay/behaviors/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade)
-- [Nav Bar Title Transition](https://github.com/Raizlabs/Swiftilities/tree/feature/heyltsjay/behaviors/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Title-Transition)
+- [Nav Bar Hairline Fade](Behaviors/Nav-Bar-Hairline-Fade)
+- [Nav Bar Title Transition](Behaviors/Nav-Bar-Title-Transition)
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - ImageHelpers
 - Keyboard
 - LicenseFormatter
-- Lifecycle
+- [Lifecycle](Pod/Classes/Lifecycle/readme.md) - Declaratively customize your app's behavior and look/feel
 - [Logging](Pod/Classes/Logging/README.md) - Log events by priority
 - Math
 - RootViewController


### PR DESCRIPTION
- add link to root README to preexisting Lifecycle README
- fix broken URLs to subdirectory READMEs and GIFs