### PR TITLE
Add Swift 5.1 to badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Swiftilities
 
 
-[![Swift 4.2](https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat)](https://swift.org)
+[![Swift 4.2, 5.1](https://img.shields.io/badge/Swift-4.2,%205.1-orange.svg?style=flat)](https://swift.org)
 [![CircleCI](https://img.shields.io/circleci/project/github/Rightpoint/Swiftilities.svg)](https://circleci.com/gh/Rightpoint/Swiftilities/tree/master)
 [![Version](https://img.shields.io/cocoapods/v/Swiftilities.svg?style=flat)](https://cocoapods.org/pods/Swiftilities)
 [![License](https://img.shields.io/cocoapods/l/Swiftilities.svg?style=flat)](https://cocoapods.org/pods/Swiftilities)


### PR DESCRIPTION
Not sure if this is the best way to do this. We could just say the latest version, or say 5.0 instead of 5.1 like the Podspec does. (There doesn’t seem to be a reason to put 5.1 in the Podspec, since it’s not a separate value in Xcode. 5.0 means 5.1 when building with an Xcode version that supports 5.1.)