### PR TITLE
Hairline Fade offset-logging toggle

### DIFF
--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -45,12 +45,19 @@ public extension NavBarHairlineFadeBehavior {
         set { navBarHairlineFadeUpdater.hairline.thickness = newValue }
         get { return navBarHairlineFadeUpdater.hairline.thickness }
     }
+    
+    var logsContentOffset: Bool {
+        set { navBarHairlineFadeUpdater.logsContentOffset = newValue }
+        get { return navBarHairlineFadeUpdater.logsContentOffset}
+    }
 
 }
 
 fileprivate final class NavBarHairlineFadeUpdater: NSObject {
 
     var contentOffsetFadeRange: ClosedRange<CGFloat> = 0...100
+
+    var logsContentOffset: Bool = false
 
     var enabled: Bool = false {
         didSet {
@@ -101,6 +108,12 @@ fileprivate extension NavBarHairlineFadeUpdater {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let shift = scrollView.contentInset.top + scrollView.contentOffset.y
         hairlineAlpha = shift.scaled(from: contentOffsetFadeRange, to: 0...1, clamped: true)
+        
+        #if DEBUG
+        if logsContentOffset {
+            print("\(shift)")
+        }
+        #endif
     }
 
     func navBarDidChangeBounds(_ navBar: UINavigationBar) {

--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -46,6 +46,8 @@ public extension NavBarHairlineFadeBehavior {
         get { return navBarHairlineFadeUpdater.hairline.thickness }
     }
     
+    /// Toggle for debug purposes:
+    /// Logs the scrollview's y-offset while scrolling which helps implementer tweak the fade range more easily.
     var logsContentOffset: Bool {
         set { navBarHairlineFadeUpdater.logsContentOffset = newValue }
         get { return navBarHairlineFadeUpdater.logsContentOffset }
@@ -57,8 +59,6 @@ fileprivate final class NavBarHairlineFadeUpdater: NSObject {
 
     var contentOffsetFadeRange: ClosedRange<CGFloat> = 0...100
 
-    // Toggle for debug purposes:
-    // Logs the scrollview's y-offset while scrolling which helps implementer tweak the fade range more easily.
     var logsContentOffset: Bool = false
 
     var enabled: Bool = false {
@@ -113,8 +113,7 @@ fileprivate extension NavBarHairlineFadeUpdater {
         
         #if DEBUG
         if logsContentOffset {
-            // This prints the content y-offset, of the scrollview, truncated to a max of 3 decimals
-            print("\(NavBarHairlineFadeUpdater.self) content y-offset: \(Double(floor(1000*shift)/1000))")
+            print("\(NavBarHairlineFadeUpdater.self) content y-offset: \(String(format: "%\(0.3)f", shift))")
         }
         #endif
     }

--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -48,7 +48,7 @@ public extension NavBarHairlineFadeBehavior {
     
     var logsContentOffset: Bool {
         set { navBarHairlineFadeUpdater.logsContentOffset = newValue }
-        get { return navBarHairlineFadeUpdater.logsContentOffset}
+        get { return navBarHairlineFadeUpdater.logsContentOffset }
     }
 
 }
@@ -57,6 +57,8 @@ fileprivate final class NavBarHairlineFadeUpdater: NSObject {
 
     var contentOffsetFadeRange: ClosedRange<CGFloat> = 0...100
 
+    // Toggle for debug purposes:
+    // Logs the scrollview's y-offset while scrolling which helps implementer tweak the fade range more easily.
     var logsContentOffset: Bool = false
 
     var enabled: Bool = false {
@@ -111,7 +113,8 @@ fileprivate extension NavBarHairlineFadeUpdater {
         
         #if DEBUG
         if logsContentOffset {
-            print("content y-offset: \(shift)")
+            // This prints the content y-offset, of the scrollview, truncated to a max of 3 decimals
+            print("\(NavBarHairlineFadeUpdater.self) content y-offset: \(Double(floor(1000*shift)/1000))")
         }
         #endif
     }

--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -111,7 +111,7 @@ fileprivate extension NavBarHairlineFadeUpdater {
         
         #if DEBUG
         if logsContentOffset {
-            print("\(shift)")
+            print("content y-offset: \(shift)")
         }
         #endif
     }

--- a/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
+++ b/Pod/Classes/Lifecycle/Behaviors/Nav-Bar-Hairline-Fade/NavBarHairlineFadeBehavior.swift
@@ -113,7 +113,7 @@ fileprivate extension NavBarHairlineFadeUpdater {
         
         #if DEBUG
         if logsContentOffset {
-            print("\(NavBarHairlineFadeUpdater.self) content y-offset: \(String(format: "%\(0.3)f", shift))")
+            print("\(NavBarHairlineFadeUpdater.self) content y-offset: \(String(format: "%0.3f", shift))")
         }
         #endif
     }


### PR DESCRIPTION
Adding some missing debug functionality for the hairline fade. This incorporates a new property/toggle in 'NavBarHairlineFadeBehavior' to log the offset of the hairline-fader's scrollview while scrolling to allow the implementer to more easily fine tune the hairline's fade range.

This addresses/closes [issue #174](https://github.com/Rightpoint/Swiftilities/issues/174)